### PR TITLE
Surface AI provider health and fallback status in frontend

### DIFF
--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -27,6 +27,7 @@ router = DefaultRouter()
 
 urlpatterns = [
     path("health/", views.health_check, name="health_check"),
+    path("health/providers/", views.providers_health, name="providers_health"),
     
     path("sessions/", views.sessions, name="sessions"),
     path("preview/", views.preview_questions, name="preview_questions"),

--- a/backend/docs/fallback-diagram.md
+++ b/backend/docs/fallback-diagram.md
@@ -1,0 +1,22 @@
+# Diagrama de fallback y manejo de errores IA
+
+Este flujo resume cómo se manejan los proveedores de generación de preguntas y los reintentos con backoff exponencial.
+
+```mermaid
+graph TD
+    A[Solicitud de generación/regeneración] --> B[Proveedor preferido (X-LLM-Provider)]
+    B -->|éxito| Z[Respuesta OK]
+    B -->|error| C[Reintento (backoff 0.75s -> 1.5s)]
+    C -->|éxito| Z
+    C -->|error| D[Fallback proveedor alterno]
+    D -->|éxito| Z
+    D -->|error| E[Proveedor secundario (placeholder Stability)]
+    E -->|éxito| Z
+    E -->|error| F[Error final providers_failed]
+```
+
+**Detalles clave**
+- Cada proveedor remoto (Gemini/Perplexity) tiene 2 intentos con backoff exponencial.
+- Si ambos fallan (por ejemplo, sin créditos), se recurre al proveedor secundario local `stability_placeholder` para mantener la continuidad del servicio.
+- El endpoint `GET /api/health/providers/` expone el estado de configuración de cada proveedor y la política de reintentos para monitoreo.
+- Los errores y fallbacks quedan registrados en el logging estructurado y (si se configura `SENTRY_DSN`) se reportan a Sentry.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,7 @@ django-cors-headers==4.4.0
 psycopg2-binary==2.9.10
 dj-database-url==2.3.0
 python-dotenv==1.1.1
+sentry-sdk==2.19.2
 
 # (Opcionales tuyos, si los usas)
 google-generativeai==0.8.5

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -211,3 +211,24 @@ a:hover { text-decoration: underline; }
     pointer-events: auto;
   }
 }
+
+/* ====== Estado del proveedor efectivo (llm-status) ====== */
+.llm-status-banner {
+  margin-top: 12px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: linear-gradient(90deg, #eef2ff, #f8fafc);
+  border: 1px solid #c7d2fe;
+  color: #111827;
+  display: grid;
+  gap: 4px;
+}
+
+.llm-status-banner strong {
+  color: #312e81;
+}
+
+.llm-status-meta {
+  font-size: 12px;
+  color: #4b5563;
+}

--- a/frontend/src/components/ModelProviderSelect.jsx
+++ b/frontend/src/components/ModelProviderSelect.jsx
@@ -1,10 +1,57 @@
 // src/components/ModelProviderSelect.jsx
-import React from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useModelProvider, PROVIDER_LABELS } from "../ModelProviderContext";
+import { fetchProvidersHealth, mapHealthByName } from "../services/healthService";
 import "../estilos/ModelProviderSelect.css";
 
 export default function ModelProviderSelect({ compact = false }) {
   const { provider, setProvider } = useModelProvider();
+  const [health, setHealth] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const data = await fetchProvidersHealth();
+        if (!alive) return;
+        setHealth(data);
+      } catch (err) {
+        if (!alive) return;
+        setError(err.message);
+      }
+    })();
+    return () => { alive = false; };
+  }, []);
+
+  const byName = useMemo(() => mapHealthByName(health || {}), [health]);
+
+  const renderStatus = (name) => {
+    const status = byName[name]?.status || "unknown";
+    const missing = byName[name]?.missing_env || [];
+    const notes = byName[name]?.notes;
+    const labelMap = {
+      ok: "OK",
+      degraded: "Degradado",
+      skipped: "Opcional",
+      unknown: "Desconocido",
+    };
+    const classMap = {
+      ok: "health-ok",
+      degraded: "health-warn",
+      skipped: "health-skip",
+      unknown: "health-unknown",
+    };
+    return (
+      <div className={`health-pill ${classMap[status] || "health-unknown"}`} title={missing.join(", ") || notes || ""}>
+        <span className="dot" />
+        <span className="text">{labelMap[status] || status}</span>
+      </div>
+    );
+  };
+
+  const retryInfo = health?.retry_strategy ? `Intentos: ${health.retry_strategy.attempts} / modo ${health.retry_strategy.mode}` : null;
+
   return (
     <div className={compact ? "model-select compact" : "model-select"}>
       {!compact && <label className="mr-2 font-semibold text-sm">Motor IA:</label>}
@@ -17,6 +64,26 @@ export default function ModelProviderSelect({ compact = false }) {
         <option value="perplexity">{PROVIDER_LABELS.perplexity}</option>
         <option value="gemini_flash_2_5_demo">{PROVIDER_LABELS.gemini_flash_2_5_demo}</option>
       </select>
+
+      <div className="health-row">
+        <div className="health-item">
+          <span className="health-name">Perplexity</span>
+          {renderStatus("perplexity")}
+        </div>
+        <div className="health-item">
+          <span className="health-name">Gemini</span>
+          {renderStatus("gemini")}
+        </div>
+        <div className="health-item">
+          <span className="health-name">Secundario</span>
+          {renderStatus("stability_placeholder")}
+        </div>
+        {(retryInfo || error) && (
+          <div className="health-meta" title={error || retryInfo}>
+            {error ? "Health no disponible" : retryInfo}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/estilos/ModelProviderSelect.css
+++ b/frontend/src/estilos/ModelProviderSelect.css
@@ -135,3 +135,78 @@
   border-color: #10b981;
   box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.15);
 }
+
+/* ---------- Health badges ---------- */
+.health-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.health-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: #4b5563;
+}
+
+.health-name {
+  font-weight: 600;
+}
+
+.health-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-weight: 600;
+  border: 1px solid transparent;
+  background: #f3f4f6;
+}
+
+.health-pill .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  display: inline-block;
+}
+
+.health-pill.health-ok {
+  border-color: #10b9814d;
+  background: #ecfdf3;
+  color: #065f46;
+}
+.health-pill.health-ok .dot { background: #10b981; }
+
+.health-pill.health-warn {
+  border-color: #fbbf244d;
+  background: #fffbeb;
+  color: #92400e;
+}
+.health-pill.health-warn .dot { background: #f59e0b; }
+
+.health-pill.health-skip {
+  border-color: #cbd5e14d;
+  background: #f8fafc;
+  color: #475569;
+}
+.health-pill.health-skip .dot { background: #cbd5e1; }
+
+.health-pill.health-unknown {
+  border-color: #e5e7eb;
+  background: #f9fafb;
+  color: #6b7280;
+}
+.health-pill.health-unknown .dot { background: #9ca3af; }
+
+.health-meta {
+  font-size: 12px;
+  color: #374151;
+  background: #eef2ff;
+  border: 1px solid #c7d2fe;
+  padding: 4px 8px;
+  border-radius: 6px;
+}

--- a/frontend/src/pages/QuizPlay.jsx
+++ b/frontend/src/pages/QuizPlay.jsx
@@ -573,6 +573,7 @@ export default function QuizPlay(props) {
   const [loading, setLoading] = useState(true);
   const [warning, setWarning] = useState(null);
   const [error, setError] = useState(null);
+  const [llmStatus, setLlmStatus] = useState(null);
 
   // Preguntas "vigentes" que se muestran
   const [questions, setQuestions] = useState([]);
@@ -1376,6 +1377,13 @@ export default function QuizPlay(props) {
         const fallback = (fbHeader ?? (data.fallback_used ? "1" : "0")) === "1";
 
         console.log("[LLM][QuizPlay] requested:", provider, "used:", used, "fallback:", fallback);
+        setLlmStatus({
+          action: "carga inicial",
+          requested: provider,
+          effective: used,
+          fallback,
+          timestamp: new Date(),
+        });
         // --------------------------------------------
 
         if (!resp.ok)
@@ -1447,6 +1455,13 @@ export default function QuizPlay(props) {
       const used = usedHeader || data.source || "(desconocido)";
       const fallback = (fbHeader ?? (data.fallback_used ? "1" : "0")) === "1";
       console.log("[LLM][Regenerate] requested:", provider, "used:", used, "fallback:", fallback);
+      setLlmStatus({
+        action: `regenerar #${idx + 1}`,
+        requested: provider,
+        effective: used,
+        fallback,
+        timestamp: new Date(),
+      });
 
       if (!resp.ok) throw new Error(data?.error || "No se pudo regenerar");
 
@@ -2638,6 +2653,18 @@ export default function QuizPlay(props) {
             {warning && <p className="qp-warning">⚠️ {warning}</p>}
             {isLoadedQuiz && (
               <p className="qp-saved-info">💾 Quiz guardado - Se guarda automáticamente tu progreso</p>
+            )}
+
+            {llmStatus && (
+              <div className="llm-status-banner" aria-live="polite">
+                <div>
+                  <strong>Proveedor efectivo:</strong> {llmStatus.effective}
+                  {llmStatus.fallback && " (fallback activado)"}
+                </div>
+                <div className="llm-status-meta">
+                  Solicitado: {llmStatus.requested} · Acción: {llmStatus.action} · {llmStatus.timestamp.toLocaleTimeString()}
+                </div>
+              </div>
             )}
 
             {/* Indicador de preguntas marcadas */}

--- a/frontend/src/services/healthService.js
+++ b/frontend/src/services/healthService.js
@@ -1,0 +1,21 @@
+// services/healthService.js
+// Utilidades para consultar la salud de los proveedores de IA expuestos por el backend
+
+const API_BASE = process.env.REACT_APP_API_BASE || "http://localhost:8000/api";
+
+export async function fetchProvidersHealth() {
+  const res = await fetch(`${API_BASE}/health/providers/`);
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Health check failed: ${res.status} ${text}`.trim());
+  }
+  return res.json();
+}
+
+export function mapHealthByName(health) {
+  const providers = health?.providers || [];
+  return providers.reduce((acc, p) => {
+    acc[p.name] = p;
+    return acc;
+  }, {});
+}


### PR DESCRIPTION
## Summary
- add a frontend health service and surface provider status/retry metadata alongside the model selector
- display effective provider and fallback usage in quiz creation and play flows so users see when resiliency kicks in
- style new health and LLM status badges for clarity in the UI

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f99a87f70832db91ae77645accf36)