### PR TITLE
Use only Gemini with rotating API keys

### DIFF
--- a/backend/api/utils/gemini_keys.py
+++ b/backend/api/utils/gemini_keys.py
@@ -1,0 +1,43 @@
+import os
+import itertools
+from typing import List
+
+_key_cycle = None
+_keys_cache: List[str] | None = None
+
+def _load_keys() -> List[str]:
+    global _keys_cache
+    if _keys_cache is not None:
+        return _keys_cache
+
+    raw_list = os.getenv("GEMINI_API_KEYS")
+    if raw_list:
+        keys = [k.strip() for k in raw_list.split(",") if k.strip()]
+    else:
+        single = os.getenv("GEMINI_API_KEY", "").strip()
+        keys = [single] if single else []
+
+    _keys_cache = keys
+    return keys
+
+def get_next_gemini_key() -> str:
+    """Return the next Gemini API key available.
+
+    If multiple keys are configured via ``GEMINI_API_KEYS`` (comma-separated),
+    the keys are rotated in round-robin order. Falls back to ``GEMINI_API_KEY``
+    for backwards compatibility.
+    """
+    global _key_cycle
+    keys = _load_keys()
+    if not keys:
+        raise RuntimeError("GEMINI_API_KEY(S) not set")
+
+    if len(keys) == 1:
+        return keys[0]
+
+    if _key_cycle is None:
+        _key_cycle = itertools.cycle(keys)
+    return next(_key_cycle)
+
+def has_any_gemini_key() -> bool:
+    return bool(_load_keys())

--- a/backend/api/utils/hint_generator.py
+++ b/backend/api/utils/hint_generator.py
@@ -1,19 +1,15 @@
 # api/utils/hint_generator.py
-import os, re
+import re
 from dotenv import load_dotenv
-import requests
 import google.generativeai as genai
+
+from api.utils.gemini_keys import get_next_gemini_key
 
 load_dotenv()
 
-PPLX_API_KEY = os.getenv("PPLX_API_KEY")
-GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
-
-genai.configure(api_key=GEMINI_API_KEY)
-gemini_model = genai.GenerativeModel('gemini-2.5-flash')
-
 THINK_BLOCK_RE = re.compile(r"</?think\b[^>]*>", re.IGNORECASE)
 ANY_TAG_RE = re.compile(r"<[^>]+>")
+
 
 def clean_hint_text(text: str) -> str:
     if not text:
@@ -24,6 +20,7 @@ def clean_hint_text(text: str) -> str:
     t = t.replace("\n", " ").strip()
     return t
 
+
 def _base_prompt(question_text: str) -> str:
     return (
         "Genera una pista muy corta (máx. 120 caracteres) para resolver la pregunta.\n"
@@ -31,53 +28,24 @@ def _base_prompt(question_text: str) -> str:
         f"Pregunta: {question_text}"
     )
 
-def generate_hint_with_perplexity(question_text: str):
-    if not PPLX_API_KEY:
-        raise ValueError("⚠️ Falta PPLX_API_KEY")
 
-    print(f"[Hint] PPLX para: {question_text[:50]}...")
-    # Usa modelo no-reasoning para evitar <think>
-    model_name = os.getenv("PPLX_MODEL", "sonar-pro")
+def _build_gemini_model():
+    api_key = get_next_gemini_key()
+    genai.configure(api_key=api_key)
+    return genai.GenerativeModel('gemini-2.5-flash')
 
-    response = requests.post(
-        "https://api.perplexity.ai/chat/completions",
-        headers={
-            "Authorization": f"Bearer {PPLX_API_KEY}",
-            "Content-Type": "application/json",
-        },
-        json={
-            "model": model_name,
-            "messages": [
-                {"role": "system", "content": "Eres un asistente que da pistas educativas sin revelar respuestas."},
-                {"role": "user", "content": _base_prompt(question_text)},
-            ],
-            "temperature": 0.3,
-           # algunas cuentas soportan esto; si no, no pasa nada
-            "response_format": {"type": "text"},
-        },
-        timeout=20,
-    )
-    response.raise_for_status()
-    data = response.json()
-    raw = data.get("choices", [{}])[0].get("message", {}).get("content", "")
-    return clean_hint_text(raw)[:120]
 
 def generate_hint_with_gemini(question_text: str):
-    if not GEMINI_API_KEY:
-        raise ValueError("⚠️ Falta GEMINI_API_KEY")
-
     print(f"[Hint] Gemini para: {question_text[:50]}...")
-    response = gemini_model.generate_content(_base_prompt(question_text))
+    model = _build_gemini_model()
+    response = model.generate_content(_base_prompt(question_text))
     raw = response.text if hasattr(response, "text") else str(response)
     return clean_hint_text(raw)[:120]
 
+
 def generate_hint(question_text: str) -> str:
     try:
-        return generate_hint_with_perplexity(question_text)
-    except Exception as e1:
-        print(f"[Hint] Error PPLX: {e1}. Probando Gemini…")
-        try:
-            return generate_hint_with_gemini(question_text)
-        except Exception as e2:
-            print(f"[Hint] Error Gemini: {e2}")
-            return "⚠️ No se pudo generar pista en este momento."
+        return generate_hint_with_gemini(question_text)
+    except Exception as e:
+        print(f"[Hint] Error Gemini: {e}")
+        return "⚠️ No se pudo generar pista en este momento."

--- a/backend/api/views_intent_router.py
+++ b/backend/api/views_intent_router.py
@@ -134,13 +134,12 @@ def _log_intent_event(result: Dict[str, Any], request) -> None:
 @api_view(["GET"])
 def intent_health(request):
     """GET /api/intent-router/health/"""
-    # Aquí podrías chequear backends reales (Gemini, Perplexity, etc.)
+    # Aquí podrías chequear backends reales (solo Gemini en uso)
     data = {
         "status": "ok",
         "backends": {
             "grammar": "ok",
             "gemini": "disabled",
-            "perplexity": "disabled",
         },
     }
     return JsonResponse(data, status=status.HTTP_200_OK)

--- a/backend/api/views_saved_quizzes.py
+++ b/backend/api/views_saved_quizzes.py
@@ -486,7 +486,7 @@ def generate_review_quiz(request, quiz_id):
                 if str(e) == "no_providers_available":
                     return JsonResponse({
                         'error': 'no_providers_available',
-                        'message': 'No hay créditos disponibles en los proveedores LLM (Perplexity/Gemini).'
+                        'message': 'No hay créditos disponibles en Gemini.'
                     }, status=status.HTTP_503_SERVICE_UNAVAILABLE)
                 else:
                     # Si falla la generación de una variante, continuar con las demás


### PR DESCRIPTION
## Summary
- add shared Gemini API key rotation helper for multiple development keys
- remove Perplexity usage across views, suggestion engine, and hint generation so only Gemini is used
- simplify provider handling and update error messages and health responses to reflect Gemini-only backend

## Testing
- python -m compileall backend/api

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921d2f882f8832dab24b26435734ef5)