### PR TITLE
Add image generation rate limiting and caching

### DIFF
--- a/backend/api/admin.py
+++ b/backend/api/admin.py
@@ -1,6 +1,6 @@
 # api/admin.py
 from django.contrib import admin
-from .models import GenerationSession, RegenerationLog
+from .models import GenerationSession, RegenerationLog, ImagePromptCache, ImageGenerationLog
 
 @admin.register(GenerationSession)
 class GenerationSessionAdmin(admin.ModelAdmin):
@@ -12,4 +12,20 @@ class GenerationSessionAdmin(admin.ModelAdmin):
 class RegenerationLogAdmin(admin.ModelAdmin):
     list_display = ("id", "session", "index", "created_at")
     search_fields = ("session__id",)
+    readonly_fields = ("created_at",)
+
+
+@admin.register(ImagePromptCache)
+class ImagePromptCacheAdmin(admin.ModelAdmin):
+    list_display = ("user_identifier", "prompt", "image_path", "expires_at", "created_at")
+    search_fields = ("prompt", "user_identifier")
+    list_filter = ("expires_at",)
+    readonly_fields = ("created_at",)
+
+
+@admin.register(ImageGenerationLog)
+class ImageGenerationLogAdmin(admin.ModelAdmin):
+    list_display = ("user_identifier", "provider", "reused_from_cache", "image_path", "created_at")
+    search_fields = ("prompt", "user_identifier", "provider")
+    list_filter = ("provider", "reused_from_cache", "created_at")
     readonly_fields = ("created_at",)

--- a/backend/api/migrations/0009_image_cache_and_logs.py
+++ b/backend/api/migrations/0009_image_cache_and_logs.py
@@ -1,0 +1,53 @@
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('api', '0008_generationsession_cover_image_history_and_more'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ImagePromptCache',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('user_identifier', models.CharField(db_index=True, max_length=255)),
+                ('prompt', models.TextField()),
+                ('prompt_hash', models.CharField(db_index=True, max_length=64)),
+                ('image_path', models.CharField(max_length=500)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('expires_at', models.DateTimeField()),
+                ('user', models.ForeignKey(blank=True, null=True, on_delete=models.SET_NULL, related_name='prompt_caches', to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+                'db_table': 'image_prompt_cache',
+                'unique_together': {('user_identifier', 'prompt_hash')},
+                'indexes': [models.Index(fields=['user_identifier', 'prompt_hash', 'expires_at'])],
+            },
+        ),
+        migrations.CreateModel(
+            name='ImageGenerationLog',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('user_identifier', models.CharField(db_index=True, max_length=255)),
+                ('prompt', models.TextField()),
+                ('provider', models.CharField(default='unknown', max_length=50)),
+                ('image_path', models.CharField(blank=True, default='', max_length=500)),
+                ('reused_from_cache', models.BooleanField(default=False)),
+                ('estimated_cost_usd', models.DecimalField(blank=True, decimal_places=4, max_digits=8, null=True)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('user', models.ForeignKey(blank=True, null=True, on_delete=models.SET_NULL, related_name='image_generations', to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+                'db_table': 'image_generation_log',
+                'indexes': [
+                    models.Index(fields=['user_identifier', 'created_at']),
+                    models.Index(fields=['provider', 'created_at']),
+                    models.Index(fields=['reused_from_cache', 'created_at']),
+                ],
+            },
+        ),
+    ]

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -69,6 +69,56 @@ class RegenerationLog(models.Model):
         return f"regen[{self.session_id}] idx={self.index} at {self.created_at}"
 
 
+class ImagePromptCache(models.Model):
+    """Cache de imágenes generadas para prompts recientes."""
+
+    user = models.ForeignKey(User, null=True, blank=True, on_delete=models.SET_NULL, related_name="prompt_caches")
+    user_identifier = models.CharField(max_length=255, db_index=True)
+    prompt = models.TextField()
+    prompt_hash = models.CharField(max_length=64, db_index=True)
+    image_path = models.CharField(max_length=500)
+    created_at = models.DateTimeField(auto_now_add=True)
+    expires_at = models.DateTimeField()
+
+    class Meta:
+        db_table = "image_prompt_cache"
+        indexes = [
+            models.Index(fields=["user_identifier", "prompt_hash", "expires_at"]),
+        ]
+        unique_together = ("user_identifier", "prompt_hash")
+
+    def __str__(self):
+        return f"cache[{self.user_identifier}] {self.prompt[:30]}..."
+
+    def is_valid(self):
+        return self.expires_at >= timezone.now()
+
+
+class ImageGenerationLog(models.Model):
+    """Registro histórico de generación y reutilización de imágenes."""
+
+    user = models.ForeignKey(User, null=True, blank=True, on_delete=models.SET_NULL, related_name="image_generations")
+    user_identifier = models.CharField(max_length=255, db_index=True)
+    prompt = models.TextField()
+    provider = models.CharField(max_length=50, default="unknown")
+    image_path = models.CharField(max_length=500, blank=True, default="")
+    reused_from_cache = models.BooleanField(default=False)
+    estimated_cost_usd = models.DecimalField(max_digits=8, decimal_places=4, null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = "image_generation_log"
+        indexes = [
+            models.Index(fields=["user_identifier", "created_at"]),
+            models.Index(fields=["provider", "created_at"]),
+            models.Index(fields=["reused_from_cache", "created_at"]),
+        ]
+
+    def __str__(self):
+        source = "cache" if self.reused_from_cache else "generated"
+        return f"{self.user_identifier} - {source} at {self.created_at}"
+
+
 class SavedQuiz(models.Model):
     """
     Cuestionarios guardados por el usuario para continuar más tarde.


### PR DESCRIPTION
## Summary
- add persistent cache and usage log models with admin visibility for image generations
- enforce 10 images per user per day with cache reuse and rate headers on image generation and regeneration
- log generation events, reuse cache entries, and expose cache/limit metadata in responses

## Testing
- Not run (environment missing `sentry_sdk` dependency prevents Django management commands)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69222a33ab10832db462fe18c76c788b)