### PR TITLE
Prioritize Gemini retries and report accurate image credits

### DIFF
--- a/backend/api/utils/gemini_keys.py
+++ b/backend/api/utils/gemini_keys.py
@@ -96,3 +96,15 @@ def get_next_gemini_key() -> str:
 
 def has_any_gemini_key() -> bool:
     return bool(_load_keys())
+
+
+def get_gemini_key_count() -> int:
+    """Return how many Gemini API keys are configured.
+
+    Useful to tune retry/backoff strategies so we exhaust all configured keys
+    before falling back to unpreferred providers.
+    """
+    try:
+        return len(_load_keys())
+    except Exception:
+        return 0


### PR DESCRIPTION
## Summary
- ensure Gemini providers use provider-aware retries based on configured key rotation before falling back to OpenAI
- expose Gemini key count and reuse it to tune retry attempts
- log image generation in previews, capture the actual provider used, and return up-to-date image credit status to the frontend

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929fbbab418832da8d065d7b70dc2f2)